### PR TITLE
Add` --clean` arg to take a list of comma-seperated files to touch

### DIFF
--- a/.github/workflows/reusable-docs.yml
+++ b/.github/workflows/reusable-docs.yml
@@ -46,7 +46,7 @@ jobs:
       continue-on-error: true
       run: |
         # Mark files the pull request modified
-        touch ${{ steps.changed_files.outputs.added_modified }}
+        python Doc/tools/touch-clean-files.py --clean ${{ steps.changed_files.outputs.added_modified }}
         # Build docs with the '-n' (nit-picky) option; convert warnings to annotations
         make -C Doc/ PYTHON=../python SPHINXOPTS="-q -n --keep-going" html 2>&1 |
             python Doc/tools/warnings-to-gh-actions.py

--- a/Doc/tools/touch-clean-files.py
+++ b/Doc/tools/touch-clean-files.py
@@ -3,7 +3,8 @@
 Touch files that must pass Sphinx nit-picky mode
 so they are rebuilt and we can catch regressions.
 """
-
+import argparse
+import csv
 from pathlib import Path
 
 wrong_directory_msg = "Must run this script from the repo root"
@@ -28,14 +29,28 @@ ALL_RST = {
     rst for rst in Path("Doc/").rglob("*.rst") if rst.parts[1] not in EXCLUDE_SUBDIRS
 }
 
-with Path("Doc/tools/.nitignore").open() as clean_files:
-    DIRTY = {
+
+parser = argparse.ArgumentParser(
+    description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+)
+parser.add_argument("-c", "--clean", help="Comma-separated list of clean files")
+args = parser.parse_args()
+
+if args.clean:
+    clean_files = next(csv.reader([args.clean]))
+    CLEAN = {
         Path(filename.strip())
         for filename in clean_files
-        if filename.strip() and not filename.startswith("#")
+        if Path(filename.strip()).is_file()
     }
-
-CLEAN = ALL_RST - DIRTY - EXCLUDE_FILES
+else:
+    with Path("Doc/tools/.nitignore").open() as ignored_files:
+        IGNORED = {
+            Path(filename.strip())
+            for filename in ignored_files
+            if filename.strip() and not filename.startswith("#")
+        }
+    CLEAN = ALL_RST - IGNORED - EXCLUDE_FILES
 
 print("Touching:")
 for filename in sorted(CLEAN):


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->

This PR updates https://github.com/python/cpython/pull/105151 to allow `Doc/tools/touch-clean-files.py` to take a `--clean` parameter, which is a comma-separated list of files to touch.

This means we can use https://github.com/Ana06/get-changed-files with paths containing spaces.

Demo PR:

* https://github.com/hugovk/cpython/pull/50

With added commit with two changed docs files, one with a space in the path:

* https://github.com/hugovk/cpython/pull/50/commits/de2d60ebb52859b9af10ed91beb69db48b8f3a13

First action check:

* https://github.com/hugovk/cpython/actions/runs/5141469456/jobs/9253999311?pr=50#step:5:18

Second action check:

* https://github.com/hugovk/cpython/actions/runs/5141469456/jobs/9254006575?pr=50#step:8:22

Second action output is used here, the two files are touched:

```
Touching:
Doc/about.rst
Doc/tools/touch-clean-files.py
Touched 2 files
```

* https://github.com/hugovk/cpython/actions/runs/5141469456/jobs/9254006575?pr=50#step:9:16


<!-- readthedocs-preview cpython-previews start -->
----
:books: Documentation preview :books:: https://cpython-previews--168.org.readthedocs.build/

<!-- readthedocs-preview cpython-previews end -->